### PR TITLE
Hyperlink DOIs to preferred resolver

### DIFF
--- a/functions/doi.fish
+++ b/functions/doi.fish
@@ -1,4 +1,4 @@
 #!/usr/bin/env fish
 function doi
-    curl -sLH "Accept: text/bibliography; style=bibtex" http://dx.doi.org/$argv | sed -r 's/[a-Z]*=/\n    &/g' | sed 's/}}/}\n}\n/g'
+    curl -sLH "Accept: text/bibliography; style=bibtex" https://doi.org/$argv | sed -r 's/[a-Z]*=/\n    &/g' | sed 's/}}/}\n}\n/g'
 end


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). Yes, a bit ironic that they would change the URL of their service, but it's now [encrypted](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org). Because the old links with the `dx` subdomain continue to work, there is no urgent need to do anything.

However, I'd hereby like to suggest to follow the new recommendation and help ramp up HTTPS traffic ;-) Cheers!